### PR TITLE
Arrumar verificação de variavel inicializada

### DIFF
--- a/IsiLang.g4
+++ b/IsiLang.g4
@@ -499,6 +499,13 @@ declaravar: tipo
 				_varValue = null;
 				_leftType = getType(_tipo);
 
+				if (!symbolTable.exists(_varName)) {
+					_symbol = new IsiVariable(_varName, _tipo);
+					symbolTable.add(_symbol);
+				} else {
+					throw new IsiSemanticException("Símbolo "+_varName+" já foi declarado.");
+				}
+
 				cleanExpression();
 			}
 			(
@@ -506,23 +513,18 @@ declaravar: tipo
 				expr {
 					_rightType = verificaTipoExpressao();
 					verificaTiposAttrib(_leftType, _rightType);
-				
+					markSymbolAsInitialized(_varName);
+
 					if (isExpressionEvaluable(_expressionString, _leftType))
 						_expressionString = evaluateExpression(_expressionString, _leftType);
 
 					_varValue = _expressionString;
+
+					IsiVariable var = (IsiVariable)symbolTable.get(_varName);
+					var.setValue(_varValue);
 				}
 			)? 
 			SC {
-				if (!symbolTable.exists(_varName)) {
-					_symbol = new IsiVariable(_varName, _tipo, _varValue);
-					symbolTable.add(_symbol);
-					
-					markSymbolAsInitialized(_varName);
-				} else {
-					throw new IsiSemanticException("Símbolo "+_varName+" já foi declarado.");
-				}
-				
 				CommandDeclaracao cmd = new CommandDeclaracao(_tipo, _varName, _varValue);
 				allCommands.peek().add(cmd);
 			};

--- a/src/DataStructures/IsiVariable.java
+++ b/src/DataStructures/IsiVariable.java
@@ -11,6 +11,11 @@ public class IsiVariable extends IsiSymbol {
 		this.value = value;
 	}
 
+	public IsiVariable(String name, String type) {
+		super(name);
+		this.type = type;
+	}
+
 	public String getType() {
 		return type;
 	}

--- a/src/Parser/IsiLangParser.java
+++ b/src/Parser/IsiLangParser.java
@@ -1357,6 +1357,13 @@ public class IsiLangParser extends Parser {
 							_varValue = null;
 							_leftType = getType(_tipo);
 
+							if (!symbolTable.exists(_varName)) {
+								_symbol = new IsiVariable(_varName, _tipo);
+								symbolTable.add(_symbol);
+							} else {
+								throw new IsiSemanticException("Símbolo "+_varName+" já foi declarado.");
+							}
+
 							cleanExpression();
 						
 			setState(181);
@@ -1371,11 +1378,15 @@ public class IsiLangParser extends Parser {
 
 									_rightType = verificaTipoExpressao();
 									verificaTiposAttrib(_leftType, _rightType);
-								
+									markSymbolAsInitialized(_varName);
+
 									if (isExpressionEvaluable(_expressionString, _leftType))
 										_expressionString = evaluateExpression(_expressionString, _leftType);
 
 									_varValue = _expressionString;
+
+									IsiVariable var = (IsiVariable)symbolTable.get(_varName);
+									var.setValue(_varValue);
 								
 				}
 			}
@@ -1383,15 +1394,6 @@ public class IsiLangParser extends Parser {
 			setState(183);
 			match(SC);
 
-							if (!symbolTable.exists(_varName)) {
-								_symbol = new IsiVariable(_varName, _tipo, _varValue);
-								symbolTable.add(_symbol);
-								
-								markSymbolAsInitialized(_varName);
-							} else {
-								throw new IsiSemanticException("Símbolo "+_varName+" já foi declarado.");
-							}
-							
 							CommandDeclaracao cmd = new CommandDeclaracao(_tipo, _varName, _varValue);
 							allCommands.peek().add(cmd);
 						


### PR DESCRIPTION
A variavel precisa ser marcada como inicializada na declaração só quando houver atribuição, mas pra isso a variavel já precisa existir na tabela de simbolos,

Então mudei pra inserir ela na tabela de simbolos antes, e depois se houver atribuição atualiza o valor.